### PR TITLE
feat: new profile actions and reducer

### DIFF
--- a/ts/features/newProfile/store/actions/index.ts
+++ b/ts/features/newProfile/store/actions/index.ts
@@ -2,6 +2,12 @@ import { ActionType, createAsyncAction } from "typesafe-actions";
 import { NetworkError } from "../../../../utils/errors";
 import NewProfile from "../../types";
 
+/**
+ * Actions for the new profile feature
+ * request: request to the backend
+ * success: response from the backend
+ * failure: error from the backend
+ */
 export const newProfileActions = createAsyncAction(
   "NEW_PROFILE_DATA_REQUEST",
   "NEW_PROFILE_DATA_SUCCESS",

--- a/ts/features/newProfile/store/actions/index.ts
+++ b/ts/features/newProfile/store/actions/index.ts
@@ -1,0 +1,11 @@
+import { ActionType, createAsyncAction } from "typesafe-actions";
+import { NetworkError } from "../../../../utils/errors";
+import NewProfile from "../../types";
+
+export const newProfileActions = createAsyncAction(
+  "NEW_PROFILE_DATA_REQUEST",
+  "NEW_PROFILE_DATA_SUCCESS",
+  "NEW_PROFILE_DATA_FAILURE"
+)<void, NewProfile, NetworkError>();
+
+export type NewProfileActions = ActionType<typeof newProfileActions>;

--- a/ts/features/newProfile/store/reducers/__tests__/index.test.ts
+++ b/ts/features/newProfile/store/reducers/__tests__/index.test.ts
@@ -1,0 +1,41 @@
+import { createStore } from "redux";
+import * as pot from "@pagopa/ts-commons/lib/pot";
+import { applicationChangeState } from "../../../../../store/actions/application";
+import { appReducer } from "../../../../../store/reducers";
+import { getTimeoutError } from "../../../../../utils/errors";
+import { newProfileActions } from "../../actions";
+import { newProfileUserMock } from "../../../types/__mocks__/NewProfileUser.mock";
+
+const genericError = getTimeoutError();
+
+describe("newProfile reducer", () => {
+  it("It should start with an empty initial state (pot.none)", () => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    expect(globalState.newProfile).toStrictEqual(pot.none);
+  });
+
+  it("It should handle the request action resulting in a loading state (pot.noneLoading)", () => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    const store = createStore(appReducer, globalState as any);
+    store.dispatch(newProfileActions.request());
+    expect(store.getState().newProfile).toStrictEqual(pot.noneLoading);
+  });
+
+  it("It should handle the success action obtaining the correct data (some(newProfileUserMock))", () => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    const store = createStore(appReducer, globalState as any);
+    store.dispatch(newProfileActions.success(newProfileUserMock));
+    expect(store.getState().newProfile).toStrictEqual(
+      pot.some(newProfileUserMock)
+    );
+  });
+
+  it("It should handle the failure action resulting in an error state (pot.noneError)", () => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    const store = createStore(appReducer, globalState as any);
+    store.dispatch(newProfileActions.failure(genericError));
+    expect(store.getState().newProfile).toStrictEqual(
+      pot.noneError(genericError)
+    );
+  });
+});

--- a/ts/features/newProfile/store/reducers/index.ts
+++ b/ts/features/newProfile/store/reducers/index.ts
@@ -1,0 +1,28 @@
+import * as pot from "@pagopa/ts-commons/lib/pot";
+import { getType } from "typesafe-actions";
+import { NetworkError } from "../../../../utils/errors";
+import { Action } from "../../../../store/actions/types";
+import NewProfile from "../../types";
+import { newProfileActions } from "../actions";
+
+export type NewProfileState = pot.Pot<NewProfile, NetworkError>;
+
+export const initialState: NewProfileState = pot.none;
+
+const reducer = (
+  state: NewProfileState = initialState,
+  action: Action
+): NewProfileState => {
+  switch (action.type) {
+    case getType(newProfileActions.request):
+      return pot.toLoading(state);
+    case getType(newProfileActions.success):
+      return pot.some(action.payload);
+    case getType(newProfileActions.failure):
+      return pot.toError(state, action.payload);
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/ts/features/newProfile/store/reducers/index.ts
+++ b/ts/features/newProfile/store/reducers/index.ts
@@ -5,10 +5,18 @@ import { Action } from "../../../../store/actions/types";
 import NewProfile from "../../types";
 import { newProfileActions } from "../actions";
 
+/**
+ * State for the new profile feature
+ */
 export type NewProfileState = pot.Pot<NewProfile, NetworkError>;
 
 export const initialState: NewProfileState = pot.none;
 
+/**
+ * Reducer for the new profile feature
+ * @param state - the current state
+ * @param action - the action to apply
+ */
 const reducer = (
   state: NewProfileState = initialState,
   action: Action

--- a/ts/features/newProfile/types/__mocks__/NewProfileUser.mock.ts
+++ b/ts/features/newProfile/types/__mocks__/NewProfileUser.mock.ts
@@ -1,0 +1,7 @@
+import NewProfile from "../index";
+
+export const newProfileUserMock: NewProfile = {
+  email: "mario.rossi@email.it",
+  name: "Mario Rossi",
+  fiscalCode: "MRSSMT801234A01H501A"
+};

--- a/ts/features/newProfile/types/index.ts
+++ b/ts/features/newProfile/types/index.ts
@@ -1,6 +1,5 @@
 /**
- * User profile data
- *
+ * NewProfile is the type of the object that represents a new user profile
  * @name the name of the user
  * @fiscalCode fiscal code of the user
  * @email email of the user

--- a/ts/features/newProfile/types/index.ts
+++ b/ts/features/newProfile/types/index.ts
@@ -1,0 +1,14 @@
+/**
+ * User profile data
+ *
+ * @name the name of the user
+ * @fiscalCode fiscal code of the user
+ * @email email of the user
+ */
+type NewProfile = {
+  name: string;
+  fiscalCode: string;
+  email: string;
+};
+
+export default NewProfile;

--- a/ts/store/actions/types.ts
+++ b/ts/store/actions/types.ts
@@ -32,6 +32,7 @@ import { FimsActions } from "../../features/fims/common/store/actions";
 import { ItwActions } from "../../features/itwallet/common/store/actions";
 import { TrialSystemActions } from "../../features/trialSystem/store/actions";
 import { ProfileSettingsActions } from "../../features/profileSettings/store/actions";
+import { NewProfileActions } from "../../features/newProfile/store/actions";
 import { AnalyticsActions } from "./analytics";
 import { ApplicationActions } from "./application";
 import { AuthenticationActions } from "./authentication";
@@ -107,7 +108,8 @@ export type Action =
   | FimsActions
   | ItwActions
   | TrialSystemActions
-  | ProfileSettingsActions;
+  | ProfileSettingsActions
+  | NewProfileActions;
 
 export type Dispatch = DispatchAPI<Action>;
 

--- a/ts/store/reducers/index.ts
+++ b/ts/store/reducers/index.ts
@@ -35,6 +35,7 @@ import { notificationsReducer } from "../../features/pushNotifications/store/red
 import { profileSettingsReducerInitialState } from "../../features/profileSettings/store/reducers";
 import { itwIdentificationInitialState } from "../../features/itwallet/identification/store/reducers";
 import { cieLoginInitialState } from "../../features/cieLogin/store/reducers";
+import newProfileReducer from "../../features/newProfile/store/reducers";
 import appStateReducer from "./appState";
 import assistanceToolsReducer from "./assistanceTools";
 import authenticationReducer, {
@@ -55,8 +56,8 @@ import entitiesReducer, {
   EntitiesState
 } from "./entities";
 import identificationReducer, {
-  IdentificationState,
   fillShowLockModal,
+  IdentificationState,
   INITIAL_STATE as identificationInitialState
 } from "./identification";
 import installationReducer from "./installation";
@@ -156,6 +157,7 @@ export const appReducer: Reducer<GlobalState, Action> = combineReducers<
   onboarding: onboardingReducer,
   notifications: notificationsReducer,
   profile: profileReducer,
+  newProfile: newProfileReducer,
   userDataProcessing: userDataProcessingReducer,
   entities: persistReducer<EntitiesState, Action>(
     entitiesPersistConfig,

--- a/ts/store/reducers/types.ts
+++ b/ts/store/reducers/types.ts
@@ -6,6 +6,7 @@ import { PersistedFeaturesState } from "../../features/common/store/reducers";
 import { PersistedLollipopState } from "../../features/lollipop/store";
 import { TrialSystemState } from "../../features/trialSystem/store/reducers";
 import { NotificationsState } from "../../features/pushNotifications/store/reducers";
+import { NewProfileState } from "../../features/newProfile/store/reducers";
 import { AppState } from "./appState";
 import { AssistanceToolsState } from "./assistanceTools";
 import { PersistedAuthenticationState } from "./authentication";
@@ -60,6 +61,7 @@ export type GlobalState = Readonly<{
   startup: StartupState;
   lollipop: PersistedLollipopState;
   trialSystem: TrialSystemState;
+  newProfile: NewProfileState;
 }>;
 
 export type PersistedGlobalState = GlobalState & PersistPartial;


### PR DESCRIPTION
## Short description
This pull request introduces a new feature to handle user profile data within the application. It includes the creation of actions, reducers, and types for the new profile functionality, along with integrating these changes into the existing application state management.

## List of changes proposed in this pull request

* **Actions**:
  * Added `newProfileActions` to handle async actions for requesting, succeeding, and failing to fetch new profile data in `ts/features/newProfile/store/actions/index.ts`

* **Reducers**:
  * Created a new reducer to manage the state of the new profile data using `@pagopa/ts-commons/lib/pot` in `ts/features/newProfile/store/reducers/index.ts`.

* **Types**:
  * Defined a new type `NewProfile` to represent user profile data in `ts/features/newProfile/types/index.ts`.

### Integration into Global State:

* **Action Types**:
  * Added `NewProfileActions` to the global `Action` type in `ts/store/actions/types.ts`.

* **Reducers**:
  * Integrated `newProfileReducer` into the global state in `ts/store/reducers/index.ts`.
  * Updated `GlobalState` type to include `NewProfileState` in `ts/store/reducers/types.ts`.

### Testing:

* [`ts/features/newProfile/store/reducers/__tests__/index.test.ts`](diffhunk://#diff-0650d8b5f8ca44f2fcf559a492a25f585c6bfbc23eea827ba3224e7dc2ec8adeR1-R41): Added tests for the new profile reducer to ensure correct handling of actions and state transitions.
* [`ts/features/newProfile/types/__mocks__/NewProfileUser.mock.ts`](diffhunk://#diff-62ee77bd8155a31583d83ab385aaa6930cf02675dc5eaab029c8d479999738eeR1-R7): Created a mock for the `NewProfile` type to be used in tests.

