### PR TITLE
feat: profile screen components and integration

### DIFF
--- a/ts/features/newProfile/components/NewProfileError.tsx
+++ b/ts/features/newProfile/components/NewProfileError.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Alert } from "@pagopa/io-app-design-system";
+import I18n from "../../../i18n";
+
+type NewProfileErrorProps = {
+  onPress: () => void;
+};
+
+const NewProfileError = ({ onPress }: NewProfileErrorProps) => (
+  <Alert
+    variant={"error"}
+    action={I18n.t("global.buttons.retry")}
+    onPress={() => onPress()}
+    title={I18n.t("profile.errors.load")}
+    content={I18n.t("global.actions.retry")}
+  />
+);
+
+export default NewProfileError;

--- a/ts/features/newProfile/components/NewProfileLoading.tsx
+++ b/ts/features/newProfile/components/NewProfileLoading.tsx
@@ -1,0 +1,19 @@
+import { LoadingSpinner } from "@pagopa/io-app-design-system";
+import React from "react";
+import { StyleSheet, View } from "react-native";
+
+const styles = StyleSheet.create({
+  container: {
+    justifyContent: "center",
+    alignItems: "center",
+    paddingTop: 16
+  }
+});
+
+export const NewProfileLoading = () => (
+  <View style={styles.container}>
+    <LoadingSpinner size={24} />
+  </View>
+);
+
+export default NewProfileLoading;

--- a/ts/features/newProfile/components/__tests__/NewProfileError.test.tsx
+++ b/ts/features/newProfile/components/__tests__/NewProfileError.test.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import NewProfileError from "../NewProfileError";
+import I18n from "../../../../i18n";
+
+describe("NewProfileError Component", () => {
+  it("matches the snapshot", () => {
+    const onPressMock = jest.fn();
+    const tree = render(<NewProfileError onPress={onPressMock} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("renders correctly", () => {
+    const onPressMock = jest.fn();
+    const { getByText } = render(<NewProfileError onPress={onPressMock} />);
+
+    // Check if the title and content texts are rendered
+    expect(getByText(I18n.t("profile.errors.load"))).toBeTruthy();
+    expect(getByText(I18n.t("global.buttons.retry"))).toBeTruthy();
+
+    // Check if the action button is rendered
+    expect(getByText(I18n.t("global.actions.retry"))).toBeTruthy();
+  });
+
+  it("calls onPress when the action button is pressed", () => {
+    const onPressMock = jest.fn();
+    const { getByText } = render(<NewProfileError onPress={onPressMock} />);
+
+    // Simulate a press on the action button
+    fireEvent.press(getByText(I18n.t("global.actions.retry")));
+
+    // Verify that onPress was called
+    expect(onPressMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ts/features/newProfile/components/__tests__/NewProfileLoading.test.tsx
+++ b/ts/features/newProfile/components/__tests__/NewProfileLoading.test.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import NewProfileLoading from "../NewProfileLoading";
+
+describe("NewProfileLoading Component", () => {
+  it("renders correctly", () => {
+    const { toJSON } = render(<NewProfileLoading />);
+    expect(toJSON()).toMatchSnapshot();
+  });
+});

--- a/ts/features/newProfile/components/__tests__/__snapshots__/NewProfileError.test.tsx.snap
+++ b/ts/features/newProfile/components/__tests__/__snapshots__/NewProfileError.test.tsx.snap
@@ -1,0 +1,243 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NewProfileError Component matches the snapshot 1`] = `
+<View
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  onTouchEnd={[Function]}
+>
+  <View
+    style={
+      [
+        {
+          "alignContent": "center",
+          "alignItems": "flex-start",
+          "flexDirection": "row",
+        },
+        {
+          "borderCurve": "continuous",
+          "borderRadius": 8,
+          "padding": 16,
+        },
+        {
+          "backgroundColor": "#FFD9D9",
+        },
+        {
+          "transform": [
+            {
+              "scale": undefined,
+            },
+          ],
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "marginRight": 12,
+        }
+      }
+    >
+      <RNSVGSvgView
+        accessibilityElementsHidden={true}
+        accessibilityLabel=""
+        accessible={false}
+        align="xMidYMid"
+        bbHeight={24}
+        bbWidth={24}
+        focusable={false}
+        height={24}
+        importantForAccessibility="no-hide-descendants"
+        meetOrSlice={0}
+        minX={0}
+        minY={0}
+        style={
+          [
+            {
+              "backgroundColor": "transparent",
+              "borderWidth": 0,
+            },
+            {
+              "color": "#5D1313",
+            },
+            {
+              "flex": 0,
+              "height": 24,
+              "width": 24,
+            },
+          ]
+        }
+        tintColor="#5D1313"
+        vbHeight={24}
+        vbWidth={24}
+        width={24}
+      >
+        <RNSVGGroup
+          fill={
+            {
+              "payload": 4278190080,
+              "type": 0,
+            }
+          }
+        >
+          <RNSVGPath
+            clipRule={0}
+            d="M7.00702 1c-.73494 0-1.41405.39209-1.78152 1.02856L.2756 11.0274c-.36747.6365-.36747 1.4206 0 2.0571l4.9499 8.8783c.36747.6365 1.04658 1.0286 1.78152 1.0286h9.94288c.7349 0 1.414-.3921 1.7815-1.0286l4.993-8.8783c.3675-.6365.3675-1.4206 0-2.0571l-4.993-8.99884C18.3639 1.39209 17.6848 1 16.9499 1H7.00702Zm5.02608 13.5549c.5676 0 1.0283-.4601 1.0283-1.0277V5.52583c0-.56758-.4601-1.02769-1.0277-1.02769-.5676 0-1.0282.46011-1.0282 1.02769v8.00137c0 .5676.4601 1.0277 1.0276 1.0277Zm0 1.9431c.8436 0 1.5275.6839 1.5275 1.5275 0 .8436-.6839 1.5275-1.5275 1.5275-.8436 0-1.5274-.6839-1.5274-1.5275 0-.8436.6838-1.5275 1.5274-1.5275Z"
+            fill={
+              {
+                "type": 2,
+              }
+            }
+            fillRule={0}
+            propList={
+              [
+                "fill",
+                "fillRule",
+              ]
+            }
+          />
+        </RNSVGGroup>
+      </RNSVGSvgView>
+    </View>
+    <View
+      style={
+        [
+          false,
+          {
+            "flex": 1,
+            "marginBottom": -6,
+          },
+        ]
+      }
+    >
+      <Text
+        allowFontScaling={false}
+        color="error-850"
+        defaultColor="bluegreyDark"
+        defaultWeight="Semibold"
+        dynamicTypeRamp="title3"
+        font="TitilliumSansPro"
+        fontStyle={
+          {
+            "fontSize": 20,
+            "lineHeight": 24,
+          }
+        }
+        maxFontSizeMultiplier={1.25}
+        style={
+          [
+            {
+              "fontSize": 20,
+              "lineHeight": 24,
+            },
+            {
+              "color": "#5D1313",
+              "fontFamily": "Titillium Sans Pro",
+              "fontStyle": "normal",
+              "fontWeight": "600",
+            },
+          ]
+        }
+        weight="Semibold"
+      >
+        Error loading the profile
+      </Text>
+      <View
+        style={
+          {
+            "height": 8,
+          }
+        }
+      />
+      <Text
+        accessibilityRole="text"
+        allowFontScaling={false}
+        color="error-850"
+        defaultColor="black"
+        defaultWeight="Bold"
+        dynamicTypeRamp="footnote"
+        font="TitilliumSansPro"
+        fontStyle={
+          {
+            "fontSize": 16,
+            "lineHeight": 24,
+          }
+        }
+        maxFontSizeMultiplier={1.25}
+        style={
+          [
+            {
+              "fontSize": 16,
+              "lineHeight": 24,
+            },
+            {
+              "color": "#5D1313",
+              "fontFamily": "Titillium Sans Pro",
+              "fontStyle": "normal",
+              "fontWeight": "400",
+            },
+          ]
+        }
+        weight="Regular"
+      >
+        An error occurred, please retry
+      </Text>
+      <View
+        style={
+          {
+            "height": 8,
+          }
+        }
+      />
+      <Text
+        ellipsizeMode="tail"
+        numberOfLines={1}
+        style={
+          [
+            {
+              "fontFamily": "Titillium Sans Pro",
+              "fontSize": 16,
+              "fontStyle": "normal",
+              "fontWeight": "700",
+            },
+            {
+              "color": "#5D1313",
+            },
+          ]
+        }
+      >
+        Retry
+      </Text>
+    </View>
+  </View>
+</View>
+`;

--- a/ts/features/newProfile/components/__tests__/__snapshots__/NewProfileLoading.test.tsx.snap
+++ b/ts/features/newProfile/components/__tests__/__snapshots__/NewProfileLoading.test.tsx.snap
@@ -1,0 +1,191 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NewProfileLoading Component renders correctly 1`] = `
+<View
+  style={
+    {
+      "alignItems": "center",
+      "justifyContent": "center",
+      "paddingTop": 16,
+    }
+  }
+>
+  <View
+    accessibilityRole="progressbar"
+    accessible={true}
+    importantForAccessibility="no-hide-descendants"
+    style={
+      {
+        "height": 24,
+        "width": 24,
+      }
+    }
+    testID="LoadingSpinnerTestID"
+  >
+    <View
+      collapsable={false}
+      style={
+        {
+          "transform": [
+            {
+              "rotateZ": "0deg",
+            },
+          ],
+        }
+      }
+      testID="LoadingSpinnerAnimatedTestID"
+    >
+      <RNSVGSvgView
+        align="xMidYMid"
+        bbHeight={24}
+        bbWidth={24}
+        fill="none"
+        focusable={false}
+        height={24}
+        meetOrSlice={0}
+        minX={0}
+        minY={0}
+        style={
+          [
+            {
+              "backgroundColor": "transparent",
+              "borderWidth": 0,
+            },
+            {
+              "flex": 0,
+              "height": 24,
+              "width": 24,
+            },
+          ]
+        }
+        vbHeight={24}
+        vbWidth={24}
+        width={24}
+      >
+        <RNSVGGroup
+          fill={null}
+          propList={
+            [
+              "fill",
+            ]
+          }
+        >
+          <RNSVGDefs>
+            <RNSVGLinearGradient
+              gradient={
+                [
+                  0,
+                  736995,
+                  1,
+                  -16040221,
+                ]
+              }
+              gradientTransform={null}
+              gradientUnits={0}
+              name="spinner-secondHalf"
+              x1="0%"
+              x2="100%"
+              y1="0%"
+              y2="0%"
+            />
+            <RNSVGLinearGradient
+              gradient={
+                [
+                  0,
+                  -16040221,
+                  1,
+                  -16040221,
+                ]
+              }
+              gradientTransform={null}
+              gradientUnits={0}
+              name="spinner-firstHalf"
+              x1="0%"
+              x2="100%"
+              y1="0%"
+              y2="0%"
+            />
+          </RNSVGDefs>
+          <RNSVGGroup
+            fill={
+              {
+                "payload": 4278190080,
+                "type": 0,
+              }
+            }
+            propList={
+              [
+                "strokeWidth",
+              ]
+            }
+            strokeWidth={3}
+          >
+            <RNSVGPath
+              d="M 1.5 12 A 10.5 10.5 0 0 1 22.5 12"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              propList={
+                [
+                  "stroke",
+                ]
+              }
+              stroke={
+                {
+                  "brushRef": "spinner-secondHalf",
+                  "type": 1,
+                }
+              }
+            />
+            <RNSVGPath
+              d="M 22.5 12 A 10.5 10.5 0 0 1 1.5 12"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              propList={
+                [
+                  "stroke",
+                ]
+              }
+              stroke={
+                {
+                  "brushRef": "spinner-firstHalf",
+                  "type": 1,
+                }
+              }
+            />
+            <RNSVGPath
+              d="M 1.5 12 A 10.5 10.5 0 0 1 1.5 11.25"
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+              propList={
+                [
+                  "stroke",
+                  "strokeLinecap",
+                ]
+              }
+              stroke={
+                {
+                  "payload": 4278927075,
+                  "type": 0,
+                }
+              }
+              strokeLinecap={1}
+            />
+          </RNSVGGroup>
+        </RNSVGGroup>
+      </RNSVGSvgView>
+    </View>
+  </View>
+</View>
+`;

--- a/ts/features/newProfile/screens/index.tsx
+++ b/ts/features/newProfile/screens/index.tsx
@@ -1,17 +1,94 @@
-import React from "react";
+import React, { useCallback, useEffect } from "react";
+import {
+  ContentWrapper,
+  Divider,
+  ListItemInfo
+} from "@pagopa/io-app-design-system";
+import * as pot from "@pagopa/ts-commons/lib/pot";
 import { IOScrollViewWithLargeHeader } from "../../../components/ui/IOScrollViewWithLargeHeader";
 import I18n from "../../../i18n";
+import NewProfile from "../types";
+import NewProfileLoading from "../components/NewProfileLoading";
+import NewProfileError from "../components/NewProfileError";
+import { useIODispatch, useIOSelector } from "../../../store/hooks";
+import { newProfileActions } from "../store/actions";
+import { selectNewProfile } from "../store/selectors";
 
-const NewProfileScreen = () => (
-  <IOScrollViewWithLargeHeader
-    title={{
-      label: I18n.t("newProfile.data.title")
-    }}
-    description={I18n.t("newProfile.data.subtitle")}
-    headerActionsProp={{ showHelp: true }}
-  >
-    {/* Content */}
-  </IOScrollViewWithLargeHeader>
-);
+const NewProfileScreen = () => {
+  const dispatch = useIODispatch();
+  const newProfile = useIOSelector(selectNewProfile);
 
+  const loadProfile = useCallback(() => {
+    dispatch(newProfileActions.request());
+  }, [dispatch]);
+
+  useEffect(() => {
+    loadProfile();
+  }, [loadProfile]);
+
+  const NewProfileContent = ({ value }: { value: NewProfile }) => (
+    <>
+      {value.name && (
+        <>
+          <ListItemInfo
+            label={I18n.t("profile.data.list.nameSurname")}
+            value={value.name}
+            testID="name"
+            icon={"profile"}
+          />
+          <Divider />
+        </>
+      )}
+      {value.fiscalCode && (
+        <>
+          <ListItemInfo
+            label={I18n.t("profile.data.list.fiscalCode")}
+            testID="fiscal-code"
+            value={value.fiscalCode}
+            icon={"creditCard"}
+          />
+          <Divider />
+        </>
+      )}
+      {value.email && (
+        <ListItemInfo
+          label={I18n.t("profile.data.list.email")}
+          value={value.email}
+          testID="email"
+          icon={"email"}
+        />
+      )}
+    </>
+  );
+
+  const NewProfileContentMapped = useCallback(
+    () =>
+      pot.fold(
+        newProfile,
+        () => <NewProfileLoading />,
+        () => <NewProfileLoading />,
+        () => <NewProfileLoading />,
+        () => <NewProfileError onPress={loadProfile} />,
+        value => <NewProfileContent value={value} />,
+        () => <NewProfileLoading />,
+        () => <NewProfileLoading />,
+        () => <NewProfileError onPress={loadProfile} />
+      ),
+    [loadProfile, newProfile]
+  );
+
+  return (
+    <IOScrollViewWithLargeHeader
+      title={{
+        label: I18n.t("newProfile.data.title")
+      }}
+      description={I18n.t("newProfile.data.subtitle")}
+      headerActionsProp={{ showHelp: true }}
+    >
+      <ContentWrapper>
+        <NewProfileContentMapped />
+      </ContentWrapper>
+    </IOScrollViewWithLargeHeader>
+  );
+};
 export default NewProfileScreen;

--- a/ts/features/newProfile/store/selectors/index.ts
+++ b/ts/features/newProfile/store/selectors/index.ts
@@ -1,0 +1,3 @@
+import { GlobalState } from "../../../../store/reducers/types";
+
+export const selectNewProfile = (state: GlobalState) => state.newProfile;


### PR DESCRIPTION
## Short description
This pull request introduces a new profile feature, including components for error handling and loading states, as well as associated tests and state management.

## List of changes proposed in this pull request

### New Components and Tests:

* [`ts/features/newProfile/components/NewProfileError.tsx`](diffhunk://#diff-7b27536105fb4c74bd0d559e30a77bb28430c36f967baadb36e7ea3ad7537dc8R1-R19): Added a new `NewProfileError` component to display error messages with a retry action.
* [`ts/features/newProfile/components/NewProfileLoading.tsx`](diffhunk://#diff-795bab041610537b2910dbbab75d446a53ef2e3e622b4a7fa8fdd47f39288484R1-R19): Added a new `NewProfileLoading` component to display a loading spinner.
* [`ts/features/newProfile/components/__tests__/NewProfileError.test.tsx`](diffhunk://#diff-3b77b043ca7b4d86d14c9dde47b6a0cfa54f4148f20cfe073dce7303af0529a6R1-R35): Added tests for the `NewProfileError` component, including snapshot and interaction tests.
* [`ts/features/newProfile/components/__tests__/NewProfileLoading.test.tsx`](diffhunk://#diff-c54b16d0e8b3b821940a061af426d33b40d044133cec272b5fd3ce8c1bb2cc86R1-R10): Added a snapshot test for the `NewProfileLoading` component.

### State Management and Screen Updates:

* [`ts/features/newProfile/screens/index.tsx`](diffhunk://#diff-6823f6fe5c9947f909287ee4febec63ef5bc822a284d7d6a426c70bd192d4e57L1-R93): Updated the `NewProfileScreen` to manage profile loading, error handling, and display profile data using the new components.
* [`ts/features/newProfile/store/selectors/index.ts`](diffhunk://#diff-cc811fcbc3b021c8b18fede4486f4d5aced1a1a2763b24253cc8306380d3808eR1-R3): Added a selector to retrieve the new profile state from the global state.

## How to test
You can just navigate from the home screen to the profile tab. Using the dev server you can simulate an error
