### PR TITLE
feat: delete profile switch

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -575,6 +575,8 @@ newProfile:
   data:
     title: Your new profile
     subtitle: Here you can find your personal and contact data used by the IO app
+  deleteFlow:
+    deleteStatus: Your profile is being deleted
 navigation:
   messages: Messages
   profile: Profile

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -575,6 +575,8 @@ newProfile:
   data:
     title: Il tuo nuovo Profilo
     subtitle: Qui trovi i tuoi dati anagrafici e di contatto utilizzati da app IO
+  deleteFlow:
+    deleteStatus: Il tuo profilo sta per essere cancellato
 navigation:
   messages: Messaggi
   profile: Profilo

--- a/ts/features/newProfile/screens/index.tsx
+++ b/ts/features/newProfile/screens/index.tsx
@@ -2,7 +2,9 @@ import React, { useCallback, useEffect } from "react";
 import {
   ContentWrapper,
   Divider,
-  ListItemInfo
+  ListItemInfo,
+  ListItemSwitch,
+  VSpacer
 } from "@pagopa/io-app-design-system";
 import * as pot from "@pagopa/ts-commons/lib/pot";
 import { IOScrollViewWithLargeHeader } from "../../../components/ui/IOScrollViewWithLargeHeader";
@@ -13,18 +15,37 @@ import NewProfileError from "../components/NewProfileError";
 import { useIODispatch, useIOSelector } from "../../../store/hooks";
 import { newProfileActions } from "../store/actions";
 import { selectNewProfile } from "../store/selectors";
+import {
+  areUserDataBeingDeletedSelector,
+  isUserDataProcessingDeleteLoadingSelector
+} from "../../../store/reducers/userDataProcessing";
+import { loadUserDataProcessing } from "../../../store/actions/userDataProcessing";
+import { UserDataProcessingChoiceEnum } from "../../../../definitions/backend/UserDataProcessingChoice";
 
 const NewProfileScreen = () => {
   const dispatch = useIODispatch();
   const newProfile = useIOSelector(selectNewProfile);
+  const userDataProcessingLoading = useIOSelector(
+    isUserDataProcessingDeleteLoadingSelector
+  );
+  const areUserDataBeingDeleted = useIOSelector(
+    areUserDataBeingDeletedSelector
+  );
 
   const loadProfile = useCallback(() => {
     dispatch(newProfileActions.request());
   }, [dispatch]);
 
+  const checkUserDataProcessing = useCallback(() => {
+    dispatch(
+      loadUserDataProcessing.request(UserDataProcessingChoiceEnum.DELETE)
+    );
+  }, [dispatch]);
+
   useEffect(() => {
     loadProfile();
-  }, [loadProfile]);
+    checkUserDataProcessing();
+  }, [checkUserDataProcessing, loadProfile]);
 
   const NewProfileContent = ({ value }: { value: NewProfile }) => (
     <>
@@ -87,6 +108,13 @@ const NewProfileScreen = () => {
     >
       <ContentWrapper>
         <NewProfileContentMapped />
+        <VSpacer size={48} />
+
+        <ListItemSwitch
+          label={I18n.t("newProfile.deleteFlow.deleteStatus")}
+          isLoading={userDataProcessingLoading}
+          value={areUserDataBeingDeleted}
+        />
       </ContentWrapper>
     </IOScrollViewWithLargeHeader>
   );

--- a/ts/store/reducers/userDataProcessing.ts
+++ b/ts/store/reducers/userDataProcessing.ts
@@ -12,6 +12,7 @@ import {
   resetUserDataProcessingRequest,
   upsertUserDataProcessing
 } from "../actions/userDataProcessing";
+import { UserDataProcessingStatusEnum } from "../../../definitions/backend/UserDataProcessingStatus";
 import { GlobalState } from "./types";
 
 export type UserDataProcessingState = {
@@ -115,3 +116,8 @@ export const isUserDataProcessingDeleteLoadingSelector = (
 
 export const isUserDataProcessingDeleteErrorSelector = (state: GlobalState) =>
   pot.isError(state.userDataProcessing.DELETE);
+
+export const areUserDataBeingDeletedSelector = (state: GlobalState) =>
+  pot.isSome(state.userDataProcessing.DELETE) &&
+  pot.some(state.userDataProcessing.DELETE).value.value?.status ===
+    UserDataProcessingStatusEnum.PENDING;


### PR DESCRIPTION
## Short description
This pull request introduces a new switch to monitor the request related to the deletion of the user profile

## List of changes proposed in this pull request

### Screen Updates:

* [`ts/features/newProfile/screens/index.tsx`](diffhunk://#diff-6823f6fe5c9947f909287ee4febec63ef5bc822a284d7d6a426c70bd192d4e57L1-R121): Updated the `NewProfileScreen` to include the new loading and error components and handle profile loading and deletion status.

### Localization:

* [`locales/en/index.yml`](diffhunk://#diff-1f1454493070fa76fae9590191905cdfc0d8d9fc724ed1bb0de35027f71fe372R578-R579): Added `deleteFlow` and `deleteStatus` for English localization.
* [`locales/it/index.yml`](diffhunk://#diff-efc72699d0eeebdb187482254790fa072511fb51631053ca553d372cd476197cR578-R579): Added `deleteFlow` and `deleteStatus` for Italian localization.

### Selectors:

* [`ts/store/reducers/userDataProcessing.ts`](diffhunk://#diff-1009136e41d7e6f7c271c28bf6de00312a635c7cb87ac567b565973422de6561R119-R123): Added a selector to check if user data is being deleted.
